### PR TITLE
Styling

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -2,7 +2,7 @@
   <div id="app">
     <h1 v-if="error !== ''">{{error}}</h1>
     <ImagePageNav v-on:change-page="updatePage"/>
-    <SearchBar v-bind:defaultSearch="defaultSearch" v-on:search="search"/>
+    <SearchBar v-bind:defaultSearch="defaultSearch" v-on:search="search" v-on:change-img-count="updateImgsPerPage($event.target.value)"/>
     <ImageContainer v-bind:images='images.results' v-if='images'/>
   </div>
 </template>
@@ -39,9 +39,10 @@ export default {
     .catch((err) => this.error = err);
   },
   methods: {
-    search(searchValue, page = 1) {
+    search(searchValue, page = 1, numImgs) {
       this.currentPage = page;
       this.currentSearch = searchValue;
+      this.imgsPerPage = Number(numImgs);
       unsplash.search.photos(searchValue, this.currentPage, this.imgsPerPage, { orientation: 'portrait' })
       .then((data) => data.json())
       .then((images) => this.images = images)
@@ -51,10 +52,15 @@ export default {
       if(this.currentPage === num) return;
       this.currentPage = num;
       const search = this.currentSearch;
-      this.search(search, num);
+      const imgsPerPage = this.imgsPerPage;
+      this.search(search, num, imgsPerPage);
     },
     updateImgsPerPage(num) {
-      this.imgsPerPage = num;
+      this.imgsPerPage = Number(num);
+      const search = this.currentSearch;
+      const page = this.currentPage;
+      const numImgs = this.imgsPerPage;
+      this.search(search, page, numImgs);
     }
   },
 }

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,5 +1,7 @@
 <template>
   <div id="app">
+    <h1 v-if="error !== ''">{{error}}</h1>
+    <ImagePageNav v-on:change-page="updatePage"/>
     <SearchBar v-bind:defaultSearch="defaultSearch" v-on:search="search"/>
     <ImageContainer v-bind:images='images.results' v-if='images'/>
   </div>
@@ -10,6 +12,7 @@ import { key } from '../key';
 import Unsplash from 'unsplash-js';
 import ImageContainer from './components/ImageContainer';
 import SearchBar from './components/SearchBar';
+import ImagePageNav from './components/ImagePageNav';
 const unsplash = new Unsplash({ accessKey: key });
 
 export default {
@@ -17,27 +20,42 @@ export default {
   components: {
     ImageContainer,
     SearchBar,
+    ImagePageNav,
   },
   data() {
     return {
       images: null,
       error: '',
       defaultSearch: 'Mountains',
+      currentSearch: 'Mountains',
+      currentPage: 1,
+      imgsPerPage: 10,
     };
   },
   created() {
-    unsplash.search.photos('mountains', 1, 10, { orientation: 'portrait' })
+    unsplash.search.photos('mountains', this.currentPage, this.imgsPerPage, { orientation: 'portrait' })
     .then((data) => data.json())
     .then((images) => this.images = images)
     .catch((err) => this.error = err);
   },
   methods: {
-    search(searchValue) {
-      unsplash.search.photos(searchValue, 1, 10, { orientation: 'portrait' })
+    search(searchValue, page = 1) {
+      this.currentPage = page;
+      this.currentSearch = searchValue;
+      unsplash.search.photos(searchValue, this.currentPage, this.imgsPerPage, { orientation: 'portrait' })
       .then((data) => data.json())
       .then((images) => this.images = images)
       .catch((err) => this.error = err);
     },
+    updatePage(num) {
+      if(this.currentPage === num) return;
+      this.currentPage = num;
+      const search = this.currentSearch;
+      this.search(search, num);
+    },
+    updateImgsPerPage(num) {
+      this.imgsPerPage = num;
+    }
   },
 }
 </script>

--- a/src/components/ImageCard.vue
+++ b/src/components/ImageCard.vue
@@ -2,7 +2,7 @@
   <div id="image-container">
     <img v-bind:src="image.urls.regular" v-bind:alt="image.alt_description" />
     <p>Picture taken by {{image.user.name}}</p>
-    <p>@{{image.user.twitter_username}}</p>
+    <p v-if="image.user.twitter_username">@{{image.user.twitter_username}}</p>
   </div>
 </template>
 
@@ -18,8 +18,14 @@ export default {
     width: 100%;
     border-radius: 25px;
   }
+
   #image-container {
     width: 25%;
     padding: 50px;
+    transition: transform .2s;
+  }
+  #image-container:hover {
+    transform: scale(1.1);
+    cursor: pointer;
   }
 </style>

--- a/src/components/ImagePageNav.vue
+++ b/src/components/ImagePageNav.vue
@@ -1,0 +1,23 @@
+<template>
+  <section id="page-nav">
+    <span>Prev</span>
+    <span 
+      v-for="page in [1,2,3,4,5]" 
+      v-bind:key="page"
+      @click="$emit('change-page', page)"
+    >
+      {{page}}
+    </span>
+    <span>Next</span>
+  </section>
+</template>
+
+<script>
+export default {
+  name: "ImagePageNav",
+}
+</script>
+
+<style scoped>
+
+</style>

--- a/src/components/SearchBar.vue
+++ b/src/components/SearchBar.vue
@@ -2,6 +2,10 @@
   <div id="search-form">
     <input @change="handleChange" placeholder="Search"/>
     <button @click="$emit('search', search)">Search</button>
+    <select>  
+      <option value="10">10</option>
+      <option value="100">100</option>
+    </select>
   </div>
 </template>
 

--- a/src/components/SearchBar.vue
+++ b/src/components/SearchBar.vue
@@ -1,10 +1,11 @@
 <template>
   <div id="search-form">
     <input @change="handleChange" placeholder="Search"/>
-    <button @click="$emit('search', search)">Search</button>
-    <select>  
+    <button @click="$emit('search', search, null, imgsPerPage)">Search</button>
+    <select @change="$emit('change-img-count', $event)">  
       <option value="10">10</option>
-      <option value="100">100</option>
+      <option value="25">25</option>
+      <option value="50">50</option>
     </select>
   </div>
 </template>
@@ -15,12 +16,16 @@ export default {
   data() {
     return {
       search: "",
+      imgsPerPage: 10,
     };
   },
   methods: {
     handleChange(e) {
       this.search = e.target.value;
     },
+    handleImgCountChange(e) {
+      this.imgsPerPage = Number(e.target.value);
+    }
   }
 }
 </script>


### PR DESCRIPTION
#### What's this PR do?
Add ability for user to view several pages of image results. Adds a message informing the user no images were found if img search returns no results. Add functionality to modify the number of images returned per page. Fixes issue where if you set number of images per page and searched again, search form would not remember the specified imgs per page.
#### Where should the reviewer start?
Open app play with searching images and changing imgs per page. Updating select menu for imgs per page should update the number of images on screen. Searching and specifying imgs per page then searching should return num imgs specified.
#### Any background context you want to provide?
Haven't done much styling or organization of the page. Will need to get into that next.
#### What are the relevant tickets?
#18 #22 #23 #17 
#### Screenshots (if appropriate)
![Screen Shot 2020-01-11 at 11 40 01 AM](https://user-images.githubusercontent.com/25031031/72209011-3a24fd80-3467-11ea-9f3c-1d6852cf9345.png)

